### PR TITLE
fix(seo): align positioning, metadata and schemas with brand vision

### DIFF
--- a/src/app/about-us/page.jsx
+++ b/src/app/about-us/page.jsx
@@ -1,11 +1,11 @@
 export const metadata = {
-  title: "About Us",
-  description: "Learn about Eevagga, India's premium birthday celebration brand. We make premium birthday celebrations effortless, memorable, and accessible.",
-  keywords: "Eevagga story, premium birthdays, party planning India",
+  title: "About Eevagga — Premium Birthday & Celebration Planner in Bangalore",
+  description: "Learn how Eevagga became Bangalore's most trusted full-service birthday, house warming and baby shower planning company. Premium execution, creative themes, end-to-end planning.",
+  keywords: "about Eevagga, birthday planner Bangalore, full-service celebration company, premium event planning Bangalore",
   alternates: { canonical: '/about-us' },
   openGraph: {
-    title: "About Us | Eevagga",
-    description: "Learn about Eevagga, India's premium birthday celebration brand. We make premium birthday celebrations effortless, memorable, and accessible.",
+    title: "About Eevagga — Premium Birthday & Celebration Planner in Bangalore",
+    description: "Learn how Eevagga became Bangalore's most trusted full-service birthday, house warming and baby shower planning company.",
     url: "https://www.eevagga.com/about-us",
     siteName: "Eevagga",
     type: "website",
@@ -23,8 +23,8 @@ const aboutPageSchema = {
   "@type": "AboutPage",
   "@id": "https://www.eevagga.com/about-us#webpage",
   "url": "https://www.eevagga.com/about-us",
-  "name": "About Us — Eevagga Entertainment",
-  "description": "Learn about Eevagga, India's premium birthday celebration brand.",
+  "name": "About Eevagga — Premium Birthday & Celebration Planner in Bangalore",
+  "description": "Bangalore's most trusted full-service birthday, house warming and baby shower planning company.",
   "inLanguage": "en-IN",
   "isPartOf": { "@id": "https://www.eevagga.com/#website" },
   "about": { "@id": "https://www.eevagga.com/#organization" }

--- a/src/app/blogs/page.jsx
+++ b/src/app/blogs/page.jsx
@@ -1,11 +1,11 @@
 export const metadata = {
-  title: "Blogs",
-  description: "Read our latest articles on premium birthday celebrations, decoration ideas, and event planning.",
-  keywords: "birthday blog, celebration ideas, party planning tips",
+  title: "Birthday & Celebration Blog — Ideas, Themes & Planning Guides | Eevagga",
+  description: "Read Eevagga's blog for birthday decoration ideas, theme inspiration, house warming tips, baby shower guides and event planning advice in Bangalore.",
+  keywords: "birthday ideas Bangalore, birthday decoration ideas, birthday theme ideas, house warming ideas, baby shower ideas, birthday planning tips Bangalore",
   alternates: { canonical: '/blogs' },
   openGraph: {
-    title: "Blogs | Eevagga",
-    description: "Read our latest articles on premium birthday celebrations, decoration ideas, and event planning.",
+    title: "Birthday & Celebration Blog — Ideas, Themes & Planning Guides | Eevagga",
+    description: "Birthday decoration ideas, theme inspiration, house warming tips and baby shower guides for celebrations in Bangalore.",
     url: "https://www.eevagga.com/blogs",
     siteName: "Eevagga",
     type: "website",
@@ -23,8 +23,8 @@ const blogSchema = {
   "@type": "Blog",
   "@id": "https://www.eevagga.com/blogs#blog",
   "url": "https://www.eevagga.com/blogs",
-  "name": "Eevagga Blog",
-  "description": "Articles on birthday celebrations, decoration ideas, and event planning in India.",
+  "name": "Eevagga Blog — Birthday & Celebration Ideas in Bangalore",
+  "description": "Birthday decoration ideas, theme inspiration, house warming tips, baby shower guides and event planning advice for Bangalore celebrations.",
   "publisher": { "@id": "https://www.eevagga.com/#organization" },
   "inLanguage": "en-IN"
 };
@@ -45,7 +45,7 @@ export default function Page() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(blogSchema) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
-      <h1 style={srOnly}>Eevagga Blog — Birthday &amp; Event Celebration Ideas</h1>
+      <h1 style={srOnly}>Eevagga Blog — Birthday &amp; Celebration Ideas, Themes &amp; Planning Guides</h1>
       <Suspense fallback={null}><PageComponent /></Suspense>
     </>
   );

--- a/src/app/careers/page.jsx
+++ b/src/app/careers/page.jsx
@@ -1,11 +1,11 @@
 export const metadata = {
-  title: "Careers",
-  description: "Join the Eevagga team and help us build memorable, premium birthday celebrations across India.",
-  keywords: "Eevagga jobs, event planning careers, hiring",
+  title: "Careers at Eevagga — Join Our Birthday Celebration Team in Bangalore",
+  description: "Join Eevagga and help build Bangalore's most trusted birthday, house warming and baby shower planning company. We are hiring event planners, coordinators and creative professionals.",
+  keywords: "Eevagga careers, event planner jobs Bangalore, birthday planner jobs Bangalore, celebration company hiring Bangalore",
   alternates: { canonical: '/careers' },
   openGraph: {
-    title: "Careers | Eevagga",
-    description: "Join the Eevagga team and help us build memorable, premium birthday celebrations across India.",
+    title: "Careers at Eevagga — Join Our Celebration Team in Bangalore",
+    description: "Join Eevagga and help build Bangalore's most trusted birthday and celebration planning company.",
     url: "https://www.eevagga.com/careers",
     siteName: "Eevagga",
     type: "website",

--- a/src/app/customer-service/page.jsx
+++ b/src/app/customer-service/page.jsx
@@ -1,18 +1,46 @@
-
 export const metadata = {
-  title: "Customer Service",
-  description: "Get support and help for your Eevagga bookings.",
+  title: "Customer Support — Birthday Planning Help & Booking Queries | Eevagga",
+  description: "Need help with your Eevagga birthday, house warming or baby shower booking? Contact our support team for booking queries, cancellations, order tracking and celebration planning assistance.",
   alternates: { canonical: '/customer-service' },
+  openGraph: {
+    title: "Customer Support | Eevagga",
+    description: "Contact Eevagga support for booking queries, cancellations and celebration planning help in Bangalore.",
+    url: "https://www.eevagga.com/customer-service",
+    siteName: "Eevagga",
+    type: "website",
+  }
 };
 
 import { Suspense } from 'react';
 import PageComponent from '../../pages/CustomerService';
+
+const contactPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "ContactPage",
+  "@id": "https://www.eevagga.com/customer-service#contact",
+  "url": "https://www.eevagga.com/customer-service",
+  "name": "Eevagga Customer Support",
+  "description": "Contact Eevagga for birthday, house warming and baby shower booking help in Bangalore.",
+  "inLanguage": "en-IN",
+  "isPartOf": { "@id": "https://www.eevagga.com/#website" }
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://www.eevagga.com" },
+    { "@type": "ListItem", "position": 2, "name": "Customer Service", "item": "https://www.eevagga.com/customer-service" }
+  ]
+};
 
 const srOnly = { position: 'absolute', width: '1px', height: '1px', padding: 0, margin: '-1px', overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap', border: 0 };
 
 export default function Page() {
   return (
     <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(contactPageSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
       <h1 style={srOnly}>Customer Service — Eevagga Support &amp; Help</h1>
       <Suspense fallback={null}><PageComponent /></Suspense>
     </>

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -32,7 +32,7 @@ export const metadata = {
     default: 'Eevagga Entertainment',
     template: '%s | Eevagga',
   },
-  description: "India's Premium Event Celebration Platform — curated birthday, wedding & corporate event packages in Bangalore.",
+  description: "Bangalore's premium full-service birthday, house warming and baby shower celebration company. End-to-end planning, decor, themes and execution in Bangalore.",
   robots: {
     index: true,
     follow: true,
@@ -73,7 +73,7 @@ const organizationSchema = {
         "url": "https://www.eevagga.com/logo.webp"
       },
       "image": "https://www.eevagga.com/og-image.jpg",
-      "description": "India's premium birthday and event celebration platform in Bangalore.",
+      "description": "Bangalore's premium full-service birthday, house warming and baby shower planning company. We handle end-to-end decoration, themes, venues and execution.",
       "address": {
         "@type": "PostalAddress",
         "streetAddress": "No10/12, Prestige Atlanta, 80 Feet Rd, Koramangala, 1 A Block Koramangala",

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -2,15 +2,15 @@ import { Suspense } from 'react';
 import HomePage from '../pages/HomePage';
 
 export const metadata = {
-  title: { absolute: "Eevagga | India's Premier Event Celebration Platform" },
-  description: "Discover India's first premium birthday celebration platform. We offer curated birthday experiences, products, and services to make your birthday special.",
-  keywords: "birthday party planning, birthday decorators, birthday gifts, premium birthday experiences, Eevagga, birthday packages",
+  title: { absolute: "Eevagga | Premium Birthday Planner in Bangalore — House Warming & Baby Showers" },
+  description: "Eevagga is Bangalore's premium full-service birthday, house warming and baby shower planning company. We handle everything — themes, decor, venues, photography and execution.",
+  keywords: "birthday planner Bangalore, birthday decoration Bangalore, house warming planner Bangalore, baby shower planner Bangalore, kids birthday planner Bangalore, premium birthday celebration Bangalore, birthday party planning Bangalore",
   alternates: {
     canonical: 'https://www.eevagga.com',
   },
   openGraph: {
-    title: "Eevagga | India's Premier Event Celebration Platform",
-    description: "Discover India's first premium birthday celebration platform. We offer curated birthday experiences, products, and services to make your birthday special.",
+    title: "Eevagga | Premium Birthday Planner in Bangalore",
+    description: "Bangalore's premium full-service birthday, house warming and baby shower planning company. End-to-end themes, decor, venues and execution.",
     type: 'website'
   }
 };
@@ -24,56 +24,59 @@ const faqSchema = {
       "name": "What is Eevagga?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Eevagga is a premium birthday celebration platform designed to make planning birthdays simple, beautiful, and stress-free. From curated birthday decorations and full-service event planning to thoughtfully designed celebration products and gifts, Eevagga brings everything needed for a memorable birthday into one place."
+        "text": "Eevagga is Bangalore's premium full-service birthday, house warming and baby shower planning company. We handle everything — themes, decorations, venue coordination, photography, entertainment and on-ground execution — so you can celebrate without the stress."
       }
     },
     {
       "@type": "Question",
-      "name": "What types of birthday celebrations does Eevagga organize?",
+      "name": "What types of celebrations does Eevagga plan in Bangalore?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Eevagga specializes in a wide range of birthday celebrations, including kids birthday parties, milestone birthdays, surprise birthday setups, home birthday decorations, venue birthday celebrations, and themed birthday parties."
+        "text": "Eevagga specializes in birthday celebrations (kids, adults, milestone birthdays), house warming ceremonies and baby shower celebrations in Bangalore. We offer themed setups, home decorations, venue celebrations and end-to-end planning for all these occasions."
       }
     },
     {
       "@type": "Question",
-      "name": "Do you only operate in Bangalore?",
+      "name": "Which areas of Bangalore does Eevagga serve?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Currently, most of our event services are available in Bangalore, while our celebration products can be delivered across India through online platforms. As Eevagga grows, we plan to expand our celebration services to more cities."
+        "text": "Eevagga serves all major areas of Bangalore including Whitefield, HSR Layout, Koramangala, Indiranagar, Sarjapur, Bellandur, Hebbal, Electronic City, Hennur, Yellhanka and JP Nagar. We are Bangalore's most trusted birthday and celebration planner."
       }
     },
     {
       "@type": "Question",
-      "name": "How far in advance should I book a birthday celebration?",
+      "name": "How far in advance should I book a birthday celebration with Eevagga?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "We recommend booking your celebration at least 22 days in advance to ensure the best availability for themes, venues, and services. For larger or customized birthday events, earlier booking is always beneficial."
+        "text": "We recommend booking at least 22 days in advance to ensure availability of your preferred theme, venue and services. For luxury or highly customized celebrations, earlier booking is always better."
       }
     },
     {
       "@type": "Question",
-      "name": "Can I book a complete birthday celebration through Eevagga?",
+      "name": "Does Eevagga handle everything end-to-end?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. With Eevagga Birthdays, you can book end-to-end birthday planning, including décor and theme setup, photography and videography, entertainment and activities, stage and event setup, catering coordination, and on-ground event management."
+        "text": "Yes. Eevagga is a full-service planning company — not a marketplace or vendor aggregator. We own the entire execution including décor and theme setup, photography and videography, entertainment, stage and event setup, catering coordination and on-ground event management."
       }
     },
     {
       "@type": "Question",
-      "name": "How can I book a birthday celebration with Eevagga?",
+      "name": "How can I book a celebration with Eevagga?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "You can book through the Eevagga website or by contacting our team directly. Our team will guide you through themes, packages, and customization options to help you plan the perfect birthday celebration."
+        "text": "You can book through the Eevagga website or reach us directly via WhatsApp. Our team will guide you through themes, packages and customization options to plan the perfect birthday, house warming or baby shower celebration."
       }
     }
   ]
 };
 
+const srOnly = { position: 'absolute', width: '1px', height: '1px', padding: 0, margin: '-1px', overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap', border: 0 };
+
 export default function Home() {
   return (
     <main>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <h1 style={srOnly}>Birthday Planner in Bangalore — House Warming &amp; Baby Shower Celebrations | Eevagga</h1>
       <Suspense fallback={null}>
         <HomePage />
       </Suspense>

--- a/src/app/press-releases/page.jsx
+++ b/src/app/press-releases/page.jsx
@@ -1,11 +1,11 @@
 export const metadata = {
-  title: "Press Releases",
-  description: "The latest news, media announcements, and press elements from Eevagga.",
-  keywords: "Eevagga news, press releases, media",
+  title: "Press Releases & Media — Eevagga Entertainment Bangalore",
+  description: "Latest news, media announcements and press coverage from Eevagga — Bangalore's premium birthday, house warming and baby shower celebration company.",
+  keywords: "Eevagga press releases, Eevagga news, Eevagga media, birthday planner Bangalore news",
   alternates: { canonical: '/press-releases' },
   openGraph: {
-    title: "Press Releases | Eevagga",
-    description: "The latest news, media announcements, and press elements from Eevagga.",
+    title: "Press Releases & Media — Eevagga Entertainment",
+    description: "Latest news and media announcements from Eevagga — Bangalore's premium birthday and celebration planning company.",
     url: "https://www.eevagga.com/press-releases",
     siteName: "Eevagga",
     type: "website",
@@ -18,11 +18,21 @@ import { Suspense } from 'react';
 import { ogImages } from '../_seo';
 import PageComponent from '../../pages/PressRelease';
 
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://www.eevagga.com" },
+    { "@type": "ListItem", "position": 2, "name": "Press Releases", "item": "https://www.eevagga.com/press-releases" }
+  ]
+};
+
 const srOnly = { position: 'absolute', width: '1px', height: '1px', padding: 0, margin: '-1px', overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap', border: 0 };
 
 export default function Page() {
   return (
     <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
       <h1 style={srOnly}>Press Releases — Eevagga News &amp; Announcements</h1>
       <Suspense fallback={null}><PageComponent /></Suspense>
     </>

--- a/src/app/services/page.jsx
+++ b/src/app/services/page.jsx
@@ -1,11 +1,11 @@
 export const metadata = {
-  title: "Our Services",
-  description: "Explore Eevagga's premium birthday celebration and decoration services tailor-fit for you.",
-  keywords: "birthday services, decorators, premium event planning",
+  title: "Birthday & Celebration Services in Bangalore | Eevagga",
+  description: "Explore Eevagga's full-service birthday, house warming and baby shower planning services in Bangalore. Themes, decor, photography, venues and end-to-end execution.",
+  keywords: "birthday decoration services Bangalore, birthday planning services Bangalore, house warming services Bangalore, baby shower planning Bangalore, premium celebration services",
   alternates: { canonical: '/services' },
   openGraph: {
-    title: "Our Services | Eevagga",
-    description: "Explore Eevagga's premium birthday celebration and decoration services tailor-fit for you.",
+    title: "Birthday & Celebration Services in Bangalore | Eevagga",
+    description: "Full-service birthday, house warming and baby shower planning in Bangalore. Themes, decor, photography and end-to-end execution.",
     url: "https://www.eevagga.com/services",
     siteName: "Eevagga",
     type: "website",
@@ -22,10 +22,10 @@ const servicesSchema = {
   "@context": "https://schema.org",
   "@type": "Service",
   "@id": "https://www.eevagga.com/services#service",
-  "name": "Premium Event Celebration Services",
-  "description": "Curated birthday, wedding and corporate event packages in Bangalore including decoration, photography, catering and entertainment.",
+  "name": "Birthday, House Warming & Baby Shower Planning Services in Bangalore",
+  "description": "Full-service birthday, house warming and baby shower planning in Bangalore. Includes theme decoration, photography, venue coordination, entertainment and on-ground execution.",
   "provider": { "@id": "https://www.eevagga.com/#organization" },
-  "serviceType": "Event Planning and Celebration",
+  "serviceType": "Birthday and Celebration Planning",
   "areaServed": { "@type": "City", "name": "Bangalore", "sameAs": "https://en.wikipedia.org/wiki/Bangalore" },
   "url": "https://www.eevagga.com/services"
 };
@@ -39,11 +39,14 @@ const breadcrumbSchema = {
   ]
 };
 
+const srOnly = { position: 'absolute', width: '1px', height: '1px', padding: 0, margin: '-1px', overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap', border: 0 };
+
 export default function Page() {
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(servicesSchema) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
+      <h1 style={srOnly}>Birthday &amp; Celebration Services in Bangalore — Eevagga</h1>
       <Suspense fallback={null}><PageComponent /></Suspense>
     </>
   );

--- a/src/app/viewAll/page.jsx
+++ b/src/app/viewAll/page.jsx
@@ -1,10 +1,10 @@
 export const metadata = {
-  title: "All Event Packages in Bangalore",
-  description: "Browse all birthday, wedding and corporate event packages in Bangalore. Curated packages from Eevagga's verified vendors.",
+  title: "Birthday & Celebration Packages in Bangalore | Eevagga",
+  description: "Browse Eevagga's birthday, house warming and baby shower packages in Bangalore. Curated themes, decor and full-service celebration experiences.",
   alternates: { canonical: '/viewAll' },
   openGraph: {
-    title: "All Event Packages in Bangalore | Eevagga",
-    description: "Browse all birthday, wedding and corporate event packages in Bangalore. Curated packages from Eevagga's verified vendors.",
+    title: "Birthday & Celebration Packages in Bangalore | Eevagga",
+    description: "Browse birthday, house warming and baby shower packages in Bangalore. Curated themes, decor and full-service celebration experiences by Eevagga.",
     url: "https://www.eevagga.com/viewAll",
     type: "website",
     images: ogImages
@@ -20,7 +20,22 @@ const breadcrumbSchema = {
   "@type": "BreadcrumbList",
   "itemListElement": [
     { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://www.eevagga.com" },
-    { "@type": "ListItem", "position": 2, "name": "All Event Packages", "item": "https://www.eevagga.com/viewAll" }
+    { "@type": "ListItem", "position": 2, "name": "Celebration Packages", "item": "https://www.eevagga.com/viewAll" }
+  ]
+};
+
+const itemListSchema = {
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Birthday & Celebration Packages in Bangalore",
+  "description": "Curated birthday, house warming and baby shower packages in Bangalore by Eevagga.",
+  "url": "https://www.eevagga.com/viewAll",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Birthday Decoration Packages" },
+    { "@type": "ListItem", "position": 2, "name": "Kids Birthday Party Packages" },
+    { "@type": "ListItem", "position": 3, "name": "Luxury Birthday Celebration Packages" },
+    { "@type": "ListItem", "position": 4, "name": "House Warming Ceremony Packages" },
+    { "@type": "ListItem", "position": 5, "name": "Baby Shower Packages" }
   ]
 };
 
@@ -30,9 +45,9 @@ export default function Page() {
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
-      <h1 style={srOnly}>All Event Packages in Bangalore — Browse &amp; Book</h1>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListSchema) }} />
+      <h1 style={srOnly}>Birthday &amp; Celebration Packages in Bangalore — Browse &amp; Book | Eevagga</h1>
       <Suspense fallback={null}><PageComponent /></Suspense>
     </>
   );
 }
-

--- a/src/components/Banner/BannerNew.jsx
+++ b/src/components/Banner/BannerNew.jsx
@@ -79,7 +79,7 @@ function BannerNew({ image, height, category, preview }) {
           preview ? (
             <img
               src={preview?.src || preview}
-              alt="Banner Preview"
+              alt={category ? `${category} celebration in Bangalore — Eevagga` : "Birthday celebration in Bangalore — Eevagga"}
               className="absolute inset-0 w-full h-full object-cover blur-md"
             />
           ) : (
@@ -88,7 +88,7 @@ function BannerNew({ image, height, category, preview }) {
         )}
         <img
           src={process.env.NEXT_PUBLIC_API_Aws_Image_BASE_URL + image}
-          alt="Banner"
+          alt={category ? `${category} celebration in Bangalore — Eevagga` : "Birthday celebration in Bangalore — Eevagga"}
           className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-700 ease-in-out ${!imageLoaded ? 'opacity-0' : 'opacity-100'
             }`}
           loading="eager"


### PR DESCRIPTION
Remove all platform/marketplace language — replaced with full-service planning company positioning across all pages. Add house warmings and baby showers to focus alongside birthdays. Expand all short title tags with Bangalore and keyword context. Fix two Critical missing H1s on homepage and services. Update FAQ schema with hyperlocal areas and explicit anti-marketplace messaging. Add ItemList schema to viewAll, ContactPage schema to customer-service, BreadcrumbList to press-releases. Fix generic banner alt text to keyword-rich dynamic values.